### PR TITLE
Fix duplicate forceget issue [Forge Help no. 10037]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,4 +185,16 @@ UpgradeLog*.htm
  # Visual Studio 2014 CTP
  **/*.sln.ide
 
+ ### VisualStudioCode ###
+.vscode/
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
  nuget.exe

--- a/src/Autodesk.Forge/Api/DerivativesApi.cs
+++ b/src/Autodesk.Forge/Api/DerivativesApi.cs
@@ -2096,7 +2096,6 @@ namespace Autodesk.Forge
             var localVarPath = DerivativesApi.GetRegionalizedURL("/modelderivative/v2/designdata/{urn}/metadata/{guid}/properties", urn, this.RegionIsEMEA);
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
-            localVarQueryParams.Add("forceget", "true");
             var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
             var localVarFormParams = new Dictionary<String, String>();
             var localVarFileParams = new Dictionary<String, FileParameter>();


### PR DESCRIPTION
Hi Team,

This issue is raised from a SO thread: [An item with the same key has already been added. Key: forceget to get GetModelviewPropertiesAsync](https://stackoverflow.com/questions/68734514/an-item-with-the-same-key-has-already-been-added-key-forceget-to-get-getmodelv/68797109)

At [line#2099](https://github.com/Autodesk-Forge/forge-api-dotnet-client/blob/7c5317aafdaf1407de6d7bd773e24e4e80b50204/src/Autodesk.Forge/Api/DerivativesApi.cs#L2099), there is a duplicate `forceget` causing the duplicate key exception that the customer is complaining about. This fix is aid for removing this line to avoid the exception throws again.

```c#
public async System.Threading.Tasks.Task<ApiResponse</*Metadata*/dynamic>> GetModelviewPropertiesAsyncWithHttpInfo(string urn, string guid, string acceptEncoding = null, List<int> objectIds = null, bool xAdsForce = false, bool forceget = false)
{

      // ...

      localVarQueryParams.Add("forceget", "true");  //!<<< this line caused the duplicate key exception.

      // ....
   
      if ( forceget != false )
          localVarQueryParams.Add ("forceget", Configuration.ApiClient.ParameterToString (forceget)); // query parameter

      // ...
}
```

Cheers,