### PR TITLE
add PostVersion method to ProjectsApi

### DIFF
--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>

--- a/src/Autodesk.Forge/Api/ProjectsApi.cs
+++ b/src/Autodesk.Forge/Api/ProjectsApi.cs
@@ -132,6 +132,7 @@ namespace Autodesk.Forge
         /// <param name="projectId">the &#x60;project id&#x60;</param>
         /// <returns>ApiResponse of TopFolders</returns>
         ApiResponse</*TopFolders*/dynamic> GetProjectTopFoldersWithHttpInfo (string hubId, string projectId);
+        
         /// <summary>
         /// 
         /// </summary>
@@ -155,6 +156,31 @@ namespace Autodesk.Forge
         /// <param name="body">describe the file the storage is created for</param>
         /// <returns>ApiResponse of StorageCreated</returns>
         ApiResponse</*StorageCreated*/dynamic> PostStorageWithHttpInfo (string projectId, CreateStorage body);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Creates a new version of an item in the 'data' domain service.
+        /// </remarks>
+        /// <exception cref="Autodesk.Forge.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="projectId">the &#x60;project id&#x60;</param>
+        /// <param name="body">describe the file the version is created for</param>
+        /// <returns>VersionCreated</returns>
+        /*StorageCreated*/
+        dynamic PostVersion(string projectId, CreateVersion body);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// Creates a new version of an item in the 'data' domain service.
+        /// </remarks>
+        /// <exception cref="Autodesk.Forge.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="projectId">the &#x60;project id&#x60;</param>
+        /// <param name="body">describe the file the version is created for</param>
+        /// <returns>ApiResponse of VersionCreated</returns>
+        ApiResponse</*StorageCreated*/dynamic> PostVersionWithHttpInfo(string projectId, CreateVersion body);
         #endregion Synchronous Operations
         #region Asynchronous Operations
         /// <summary>
@@ -1162,6 +1188,108 @@ namespace Autodesk.Forge
                 localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
                 /*(StorageCreated)*/ Configuration.ApiClient.Deserialize(localVarResponse, typeof(StorageCreated)));
             
+        }
+
+        /// <summary>
+        ///  Creates a new version of an item in the 'data' domain service.
+        /// </summary>
+        /// <exception cref="Autodesk.Forge.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="projectId">the &#x60;project id&#x60;</param>
+        /// <param name="body">describe the file the version is created for</param>
+        /// <returns>VersionCreated</returns>
+        public /*StorageCreated*/dynamic PostVersion(string projectId, CreateVersion body)
+        {
+            ApiResponse</*StorageCreated*/dynamic> localVarResponse = PostVersionWithHttpInfo(projectId, body);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  Creates a new version of an item in the 'data' domain service.
+        /// </summary>
+        /// <exception cref="Autodesk.Forge.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="projectId">the &#x60;project id&#x60;</param>
+        /// <param name="body">describe the file the version is created for</param>
+        /// <returns>ApiResponse of VersionCreated</returns>
+        public ApiResponse< /*StorageCreated*/dynamic> PostVersionWithHttpInfo(string projectId, CreateVersion body)
+        {
+            // verify the required parameter 'projectId' is set
+            if (projectId == null)
+                throw new ApiException(400, "Missing required parameter 'projectId' when calling ProjectsApi->PostVersion");
+            // verify the required parameter 'body' is set
+            if (body == null)
+                throw new ApiException(400, "Missing required parameter 'body' when calling ProjectsApi->PostVersion");
+
+            var localVarPath = "/data/v1/projects/{project_id}/versions";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new Dictionary<String, String>();
+            var localVarHeaderParams = new Dictionary<String, String>(Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+                "application/vnd.api+json"
+            };
+            String localVarHttpContentType = Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+                "application/vnd.api+json",
+                "application/json"
+            };
+            String localVarHttpHeaderAccept = Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            // set "format" to json by default
+            // e.g. /pet/{petId}.{format} becomes /pet/{petId}.json
+            localVarPathParams.Add("format", "json");
+            if (projectId != null) localVarPathParams.Add("project_id", Configuration.ApiClient.ParameterToString(projectId)); // path parameter
+            if (body != null && body.GetType() == typeof(byte[])) // http body (model) parameter
+            {
+                localVarPostBody = body; // byte array
+            }
+            else if (body != null
+                     && (body.GetType() == typeof(System.IO.FileStream)
+                         || body.GetType() == typeof(System.IO.BinaryReader)
+                         || body.GetType() == typeof(System.IO.BufferedStream)
+                            || body.GetType() == typeof(System.IO.MemoryStream)
+                            || body.GetType() == typeof(System.IO.StreamReader)
+                           )
+                    )
+            {
+                localVarPostBody = Configuration.ApiClient.toByteArray(body); // byte array
+            }
+            else if (body != null)
+            {
+                localVarPostBody = Configuration.ApiClient.Serialize(body);
+            }
+
+            // authentication (oauth2_access_code) required
+            // oauth required
+            if (!String.IsNullOrEmpty(Configuration.AccessToken))
+            {
+                localVarHeaderParams["Authorization"] = "Bearer " + Configuration.AccessToken;
+            }
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse)Configuration.ApiClient.CallApi(localVarPath,
+                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int)localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("PostVersion", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse</*StorageCreated*/dynamic>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Name, x => x.Value.ToString()),
+                /*(VersionCreated)*/ Configuration.ApiClient.Deserialize(localVarResponse, typeof(VersionCreated)));
+
         }
 
         /// <summary>

--- a/src/Autodesk.Forge/Autodesk.Forge.csproj
+++ b/src/Autodesk.Forge/Autodesk.Forge.csproj
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Forge SDK
 


### PR DESCRIPTION
The PostVersion is missing in the source code. This method creates a new version of an item in the 'data' domain service. It is essential for using BIM 360 API to upload files when a duplicate name exists. 