### PR TITLE
Add v3 IFC conversion method to `ConversionMethodEnum`.

### DIFF
--- a/src/Autodesk.Forge/Model/JobSvf2OutputPayloadAdvanced.cs
+++ b/src/Autodesk.Forge/Model/JobSvf2OutputPayloadAdvanced.cs
@@ -75,7 +75,12 @@ namespace Autodesk.Forge.Model
             /// Enum Modern for "modern"
             /// </summary>
             [EnumMember(Value = "modern")]
-            Modern
+            Modern,
+            /// <summary>
+            /// Enum Modern for "v3"
+            /// </summary>
+            [EnumMember(Value = "v3")]
+            V3
         }
 
         /// <summary>

--- a/src/Autodesk.Forge/Model/JobSvfOutputPayloadAdvanced.cs
+++ b/src/Autodesk.Forge/Model/JobSvfOutputPayloadAdvanced.cs
@@ -75,7 +75,12 @@ namespace Autodesk.Forge.Model
             /// Enum Modern for "modern"
             /// </summary>
             [EnumMember(Value = "modern")]
-            Modern
+            Modern,
+            /// <summary>
+            /// Enum Modern for "v3"
+            /// </summary>
+            [EnumMember(Value = "v3")]
+            V3
         }
 
         /// <summary>


### PR DESCRIPTION
Hi Team,

As the v3 IFC conversion method has been released for a couple of months since June 2022, adding it to `ConversionMethodEnum`. Otherwise, customers cannot use it with our dotNET API client.

Cheers,