### PR TITLE
fix rest response

### DIFF
--- a/src/Autodesk.Forge/Api/ProjectsApi.cs
+++ b/src/Autodesk.Forge/Api/ProjectsApi.cs
@@ -1274,8 +1274,8 @@ namespace Autodesk.Forge
             }
 
             // make the HTTP request
-            IRestResponse localVarResponse = (IRestResponse)Configuration.ApiClient.CallApi(localVarPath,
-                Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+            RestResponse localVarResponse = (RestResponse)Configuration.ApiClient.CallApi(localVarPath,
+                Method.Post, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
                 localVarPathParams, localVarHttpContentType);
 
             int localVarStatusCode = (int)localVarResponse.StatusCode;


### PR DESCRIPTION
the call to `IRestResponse` is deprecated as of RestSharp v107+

Replaced `IRestResponse` with `RestResponse` in `ProjectsAPI`

https://stackoverflow.com/questions/70921065/irestresponse-could-not-be-found
https://restsharp.dev/v107/#restsharp-v107